### PR TITLE
chore(ci): fixing build versions for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: build
+        run: go build
+
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -23,6 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29
+
   build-docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,60 +7,65 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: compile and release
-        uses: ngs/go-release.action@v1.0.1
+        uses: ngs/go-release.action@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOARCH: amd64
           GOOS: linux
           EXTRA_FILES: "LICENSE"
+
   release-linux-arm:
     name: release linux/386
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: compile and release
-        uses: ngs/go-release.action@v1.0.1
+        uses: ngs/go-release.action@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOARCH: "arm"
           GOOS: linux
           EXTRA_FILES: "LICENSE"
+
   release-linux-arm64:
     name: release linux/amd64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: compile and release
-        uses: ngs/go-release.action@v1.0.1
+        uses: ngs/go-release.action@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOARCH: arm64
           GOOS: linux
           EXTRA_FILES: "LICENSE"
+
   release-darwin-amd64:
     name: release darwin/amd64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: compile and release
-        uses: ngs/go-release.action@v1.0.1
+        uses: ngs/go-release.action@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOARCH: amd64
           GOOS: darwin
           EXTRA_FILES: "LICENSE"
+
   release-windows-amd64:
     name: release windows/amd64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: compile and release
-        uses: ngs/go-release.action@v1.0.1
+        uses: ngs/go-release.action@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOARCH: amd64
           GOOS: windows
           EXTRA_FILES: "LICENSE"
+
   release-docker:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Older version of the go release action was using go 1.11 updated to cut releases with go 1.14