### PR TITLE
feat(scratch): 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd -u 10001 scratchuser
 
 FROM scratch AS run
 
-COPY --from=0 /etc/passwd /etc/passwd
+COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /app/sqs-prometheus-exporter .
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,16 @@ COPY main.go go.mod go.sum ./
 RUN go mod download && \
 	CGO_ENABLED=0 GOOS=linux go build
 
+RUN useradd -u 10001 scratchuser
+
+
 FROM scratch AS run
 
+COPY --from=0 /etc/passwd /etc/passwd
 COPY --from=build /app/sqs-prometheus-exporter .
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 EXPOSE 8080
 
-
+USER scratchuser
 ENTRYPOINT [ "./sqs-prometheus-exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,12 @@ COPY main.go go.mod go.sum ./
 RUN go mod download && \
 	CGO_ENABLED=0 GOOS=linux go build
 
-FROM gcr.io/distroless/base-debian11 AS run
+FROM scratch AS run
 
 COPY --from=build /app/sqs-prometheus-exporter .
-
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 EXPOSE 8080
 
-USER nonroot:nonroot
 
 ENTRYPOINT [ "./sqs-prometheus-exporter" ]


### PR DESCRIPTION
moving the run image to scratch over distroless so its easier to maintain, the core binary uses very little of the current distroless packages